### PR TITLE
Allow filtering for multiseater mounts in Party

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processName": "ffxiv_dx11"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/BetterMountRoulette.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/BetterMountRoulette.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/BetterMountRoulette.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/BetterMountRoulette.csproj
+++ b/BetterMountRoulette.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0.8</Version>
+    <Version>1.1.1.0</Version>
     <Description>todo.</Description>
     <PackageProjectUrl>https://github.com/CMDRNuffin/BetterMountRoulette</PackageProjectUrl>
     <Configurations>Release;Debug</Configurations>

--- a/Config/Data/MountGroup.cs
+++ b/Config/Data/MountGroup.cs
@@ -13,4 +13,7 @@ internal sealed class MountGroup
 
     [JsonProperty(PropertyName = "IncludeNewMounts")]
     public bool IncludedMeansActive { get; set; }
+
+    [JsonProperty(PropertyName = "ForceMultiseatersInParty")]
+    public bool ForceMultiseatersInParty { get; set; } = false;
 }

--- a/UI/ConfigWindow.cs
+++ b/UI/ConfigWindow.cs
@@ -227,6 +227,12 @@ internal sealed class ConfigWindow : IWindow
 
         bool enableNewMounts = !group.IncludedMeansActive;
         _ = ImGui.Checkbox("Enable new mounts on unlock", ref enableNewMounts);
+        
+        bool forceMultiseatersInParty = group.ForceMultiseatersInParty;
+        if (ImGui.Checkbox("Use only multiseater mounts in parties", ref forceMultiseatersInParty))
+        {
+            group.ForceMultiseatersInParty = forceMultiseatersInParty;
+        }
 
         List<MountData> unlockedMounts = _plugin.MountRegistry.GetUnlockedMounts();
         if (enableNewMounts == group.IncludedMeansActive)
@@ -277,7 +283,7 @@ internal sealed class ConfigWindow : IWindow
                         // commented-out code needs to be preserved (for now)
                         _plugin.WindowManager.ConfirmYesNo(
                             "Are you sure?",
-                            $"Do you really want to {selectText}select all {pageInfo}?",
+                            $"Do you really want to {selectText} all {pageInfo}?",
                             () =>
                             {
                                 List<MountData> unlockedMounts = _plugin.MountRegistry.GetUnlockedMounts();

--- a/Util/ActionHandler.cs
+++ b/Util/ActionHandler.cs
@@ -6,6 +6,7 @@ using BetterMountRoulette.UI;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Hooking;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Group;
 
 using System;
 
@@ -67,10 +68,21 @@ internal sealed class ActionHandler : IDisposable
         {
             MountGroup? mountGroup = CharacterConfig.GetMountGroup(groupName);
 
+            int partySize = GroupManager.Instance()->MemberCount;
+
             uint newActionID = 0;
             if (mountGroup is not null)
             {
-                newActionID = _mountRegistry.GetRandom(ActionManager.Instance(), mountGroup);
+                if (mountGroup.ForceMultiseatersInParty && partySize > 1)
+                {
+                    // In future versions we could ask the player if they want to only use mounts that can seat all party members.
+                    // In the meantime, we look for any mounts with at least 1 extra seat.
+                    newActionID = _mountRegistry.GetRandomWithExtraSeats(ActionManager.Instance(), mountGroup, 1);
+                }
+                else
+                {
+                    newActionID = _mountRegistry.GetRandom(ActionManager.Instance(), mountGroup);
+                }
             }
 
             if (newActionID is not 0)

--- a/Util/ActionHandler.cs
+++ b/Util/ActionHandler.cs
@@ -6,7 +6,6 @@ using BetterMountRoulette.UI;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Hooking;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using FFXIVClientStructs.FFXIV.Client.Game.Group;
 
 using System;
 
@@ -68,21 +67,10 @@ internal sealed class ActionHandler : IDisposable
         {
             MountGroup? mountGroup = CharacterConfig.GetMountGroup(groupName);
 
-            int partySize = GroupManager.Instance()->MemberCount;
-
             uint newActionID = 0;
             if (mountGroup is not null)
             {
-                if (mountGroup.ForceMultiseatersInParty && partySize > 1)
-                {
-                    // In future versions we could ask the player if they want to only use mounts that can seat all party members.
-                    // In the meantime, we look for any mounts with at least 1 extra seat.
-                    newActionID = _mountRegistry.GetRandomWithExtraSeats(ActionManager.Instance(), mountGroup, 1);
-                }
-                else
-                {
-                    newActionID = _mountRegistry.GetRandom(ActionManager.Instance(), mountGroup);
-                }
+                newActionID = _mountRegistry.GetRandom(ActionManager.Instance(), mountGroup);
             }
 
             if (newActionID is not 0)

--- a/Util/MountData.cs
+++ b/Util/MountData.cs
@@ -18,6 +18,8 @@ internal sealed class MountData
 
     public bool Unlocked { get; set; }
 
+    public int ExtraSeats { get; set; }
+
     public MountData(TextureHelper textureHelper, SeString name)
     {
         _textureHelper = textureHelper;

--- a/Util/MountRegistry.cs
+++ b/Util/MountRegistry.cs
@@ -88,6 +88,7 @@ internal sealed class MountRegistry
                    IconID = mount.Icon,
                    ID = mount.RowId,
                    Unlocked = GameFunctions.HasMountUnlocked(mount.RowId),
+                   ExtraSeats = mount.ExtraSeats,
                };
     }
 
@@ -120,5 +121,28 @@ internal sealed class MountRegistry
 
         int index = Random.Shared.Next(available.Count);
         return available[index].ID;
+    }
+
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Non-critical use of randomness, so we prefer speed over security")]
+    public uint GetRandomWithExtraSeats(Pointer<ActionManager> actionManager, MountGroup group, int extraSeats = 1)
+    {
+        List<MountData> available = GetAvailableMounts(actionManager, group);
+        var withExtraSeats = available.Where(x => x.ExtraSeats >= extraSeats).ToList();
+
+        if (withExtraSeats.Count > 0)
+        {
+            int index = Random.Shared.Next(withExtraSeats.Count);
+            return withExtraSeats[index].ID;
+        }
+        else if (available.Count is 0)
+        {
+            return 0;
+        }
+        else
+        {
+            // Fall back to regular mounts if none have extra seats.
+            int index = Random.Shared.Next(available.Count);
+            return available[index].ID;
+        }
     }
 }


### PR DESCRIPTION
This feature is, in a nutshell, exactly what the plugin Mounting Party was intended to achieve.
As requested [here](https://github.com/goatcorp/DalamudPluginsD17/pull/1300#issuecomment-1438043824), I've turned it into a Better Mount Roulette feature.
MountGroups now have a `ForceMultiseatersInParty` boolean setting.
When a Mount Roulette action is intercepted, if the selected group has this setting enabled, and the player is in a Party with at least one other person, the resulting Randomized Mounts are filtered by `ExtraSeats >= 1`. If no mounts with extra seats are found, it falls back to the default randomizing behavior.